### PR TITLE
Do not add like to comment if it is on your own comment

### DIFF
--- a/imports/ui/Comment.jsx
+++ b/imports/ui/Comment.jsx
@@ -3,7 +3,8 @@ import { Card, Feed, Icon } from 'semantic-ui-react';
 
 class Comment extends Component {
   addLike = () => {
-    Meteor.call('likes.insert', this.props.data._id, this.props.postId);
+    this.props.data.owner !== Meteor.userId() ?
+      Meteor.call('likes.insert', this.props.data._id, this.props.postId) : alert('Cannot like your own comment');
   }
 
   render() {


### PR DESCRIPTION
Add logic to the Meteor method likes.insert so that you cannot add a like to your own comment